### PR TITLE
Add verificação de dono da entidade PR #432

### DIFF
--- a/layouts/parts/singles/opportunity-registrations--form.php
+++ b/layouts/parts/singles/opportunity-registrations--form.php
@@ -2,7 +2,7 @@
 
 use MapasCulturais\App;
 
-$url_atual = "http://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+$url_atual = $app->view->controller->id;
 
 $app = App::i();
 
@@ -12,12 +12,7 @@ $userRelation = $entity->evaluationMethodConfiguration->getUserRelation($user);
 
 $btnHideShow = false;
 
-function isOwnsOfEntity($user, $entity)
-{
-    return $user->id == $entity->owner->userId;
-}
-
-if (strpos($url_atual, 'oportunidade') !== false) {
+if (strpos($url_atual, 'opportunity') !== false) {
     $btnHideShow = true;
 } else {
     $btnHideShow = false;
@@ -27,7 +22,7 @@ if ($entity->isRegistrationOpen()) : ?>
     <?php if ($app->auth->isUserAuthenticated()) : ?>
 
         <!-- // CASO ESSE USUÁRIO FOI ALGUM AVALIADOR ou for o dono da entidade, então O FORM NAO APARECERÁ PARA ELE  -->
-        <?php if (empty($userRelation) && !isOwnsOfEntity($user, $entity)) : ?>
+        <?php if (empty($userRelation) && !($user->id == $entity->owner->userId)) : ?>
             <form class="registration-form clearfix">
                 <p class="registration-help white-top" style="font-size: 14px;"><?php \MapasCulturais\i::_e("Para iniciar sua inscrição, selecione o agente responsável. Ele deve ser um agente individual (pessoa física), com um CPF válido preenchido."); ?></p>
                 <div class="registration-form-content">

--- a/layouts/parts/singles/opportunity-registrations--form.php
+++ b/layouts/parts/singles/opportunity-registrations--form.php
@@ -5,10 +5,17 @@ use MapasCulturais\App;
 $url_atual = "http://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
 
 $app = App::i();
+
 $user = $app->user;
 
-$usuario = $entity->evaluationMethodConfiguration->getUserRelation($user);
+$userRelation = $entity->evaluationMethodConfiguration->getUserRelation($user);
+
 $btnHideShow = false;
+
+function isOwnsOfEntity($user, $entity)
+{
+    return $user->id == $entity->owner->userId;
+}
 
 if (strpos($url_atual, 'oportunidade') !== false) {
     $btnHideShow = true;
@@ -18,8 +25,9 @@ if (strpos($url_atual, 'oportunidade') !== false) {
 
 if ($entity->isRegistrationOpen()) : ?>
     <?php if ($app->auth->isUserAuthenticated()) : ?>
-        <?php if (empty($usuario)) : //SE CASO ESSE USUÁRIO FOI ALGUM AVALIADOR O FORM NAO APARECERÁ PARA ELE 
-        ?>
+
+        <!-- // CASO ESSE USUÁRIO FOI ALGUM AVALIADOR ou for o dono da entidade, então O FORM NAO APARECERÁ PARA ELE  -->
+        <?php if (empty($userRelation) && !isOwnsOfEntity($user, $entity)) : ?>
             <form class="registration-form clearfix">
                 <p class="registration-help white-top" style="font-size: 14px;"><?php \MapasCulturais\i::_e("Para iniciar sua inscrição, selecione o agente responsável. Ele deve ser um agente individual (pessoa física), com um CPF válido preenchido."); ?></p>
                 <div class="registration-form-content">


### PR DESCRIPTION
Responsáveis:  
@ericsonmoreira 

Linked Issue:  
Close #432

### 📝 Descrição

Atualmente, mesmo como `administrador` da `oportunidade`, é possível se inscrever na `oportunidade` a qual seja `administrador`. Isso não deve ser permitido. Portanto, deverá haver uma **validação** para que quando o `administrador` acesse uma `oportunidade` a qual ele administra, então **não deverá haver a opção para se inscrever nesta oportunidade**.

### 🖥 Passos a passo para teste

> Deve ser possível cadastrar-se em uma oportunidade caso não seja o administrador dono daquela `oportunidade`

1. Criar uma `oportunidade` ou `sub-projeto` (cadastrando uma `oportunidade` nesse `sub-projeto`) 
2. Verificar o `formulário` de inscrição **não** aparece caso se esteja logado com o usuário que criou aquela oportinidade
3. Verificar o `formulário` de inscrição aparece caso se esteja logado com um usuário que **não** criou aquela oportinidade

## 📋 Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
