### PR TITLE
#220 Adicionar Lazy Loading nos botoes de compartilhamento nas redes …

### DIFF
--- a/layouts/parts/redes-sociais.php
+++ b/layouts/parts/redes-sociais.php
@@ -1,4 +1,9 @@
-<div class="widget">
+<?php
+    $app_mode = env('APP_MODE', 'production');
+    $is_production = $app_mode == 'production';
+    if($is_production){
+?>
+    <div class="widget">
     <h3><?php \MapasCulturais\i::_e("Compartilhar");?></h3>
     <!-- LinkedIn -->
     <div>
@@ -28,6 +33,11 @@
         </div>
     </div>
 </div>
+
+<?php
+    }
+?>
+
 <div class="btn-social-share" data-href="<?php echo $entity->singleUrl; ?>" data-type="button_count"></div>
 <?php if ($this->isEditable() || $entity->twitter || $entity->facebook || $entity->googleplus || $entity->instagram): ?>
 <div class="widget">


### PR DESCRIPTION
by @lucastandy @victorMagalhaesPacheco

## Contexto

Atualmente no mapa da saúde o mesmo carrega os botões das redes sociais para compartilhamento, dependendo do bloqueio de acesso, a página pode demorar 15 segundos tentando conectar os botões na página.

## Observações
Em 18/10/2021, no Plantão de Dúvidas, ficou alinhado de ser aplicado uma verificação na variável de ambiente “APP_MODE” para analisar se a aplicação está rodando no ambiente de produção.
Se o mapas rodar em produção, os botões das redes sociais serão mostrados, caso contrário, não serão exibidos.
Essa inteligência no código foi necessária devido ao não carregamento das redes sociais dentro da rede da ESP, em virtude de bloqueios e demais restrições nesses conteúdos.